### PR TITLE
Fixed Tests classes namespace (capitalization) to pass travis-ci build

### DIFF
--- a/tests/Facades/Talk.php
+++ b/tests/Facades/Talk.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nahid\talk\tests\Facades;
+namespace Nahid\Talk\Tests\Facades;
 
 use GrahamCampbell\TestBenchCore\FacadeTrait;
 use Nahid\Talk\Tests\TestCase;

--- a/tests/TalkServiceProviderTest.php
+++ b/tests/TalkServiceProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nahid\talk\tests;
+namespace Nahid\Talk\Tests;
 
 use GrahamCampbell\TestBenchCore\ServiceProviderTrait;
 use Nahid\Talk\Talk;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nahid\talk\tests;
+namespace Nahid\Talk\Tests;
 
 use GrahamCampbell\TestBench\AbstractPackageTestCase;
 use Nahid\Talk\TalkServiceProvider;


### PR DESCRIPTION
I have been runing tests on my local machine (and it fails). I have fixed that namespace capitalization, re-run test and it passed. Hope this PR also made travis-ci builds are passes.