### PR TITLE
Fixes Class 'Pusher' not found

### DIFF
--- a/src/Live/Broadcast.php
+++ b/src/Live/Broadcast.php
@@ -5,7 +5,7 @@ namespace Nahid\Talk\Live;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Contracts\Config\Repository;
 use Nahid\Talk\Messages\Message;
-use Pusher;
+use Pusher\Pusher;
 
 class Broadcast
 {


### PR DESCRIPTION
Use the correct cluster in config file
`'options' => [
                'cluster' => 'ap2',
                'encrypted' => true,
            ],
`