### PR TITLE
Fixed issue 91 - not being able to view messages of soft-deleted users

### DIFF
--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -50,7 +50,7 @@ class Message extends Model
    * */
     public function user()
     {
-        return $this->belongsTo(config('talk.user.model', 'App\User'));
+        return $this->belongsTo(config('talk.user.model', 'App\User'))->withTrashed();
     }
 
     /*


### PR DESCRIPTION
added ->withTrashed() to user relationship on message model to allow messages to still be viewed after a user has been deleted