### PR TITLE
Remove extra query to determine if record exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,11 @@
         }
     ],
   "require": {
-    "php": "^5.6 || ^7.0 || ^7.1 || ^7.2",
+    "php": ">=5.6",
     "illuminate/contracts": ">=5.1.0",
     "illuminate/support": ">=5.1.0",
-    "sebastian-berc/repositories": "^1.0",
     "nesbot/carbon": "^2.22",
-    "pusher/pusher-php-server": "^3.0",
+    "pusher/pusher-php-server": "^5.0",
     "predis/predis": "~1.1.1",
     "mpratt/embera": "^1.9"
   },

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace Nahid\Talk;
+
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
+
+abstract class BaseRepository
+{
+    /**
+     * @var Model
+     */
+    protected $model = null;
+
+    public function __construct()
+    {
+        $this->model = $this->makeModel();
+    }
+
+    public function __call($method, $arguments)
+    {
+        return call_user_func_array([$this->model, $method], $arguments);
+    }
+
+    protected function makeModel()
+    {
+        $model = $this->takeModel();
+        if (is_null($this->model)) {
+            $this->model = new $model();
+        }
+
+        return $this->model;
+    }
+
+    abstract public function takeModel();
+
+    public function update($id, $data)
+    {
+        $model = $this->model->find($id);
+
+        return $model->update($data);
+    }
+
+
+    public function create($data)
+    {
+        return $this->model->create($data);
+    }
+
+    public function delete($id)
+    {
+        $model = $this->model->find($id);
+
+        return $model->delete();
+    }
+}

--- a/src/Conversations/ConversationRepository.php
+++ b/src/Conversations/ConversationRepository.php
@@ -56,10 +56,10 @@ class ConversationRepository extends Repository
                         }
                     );
             }
-        );
+        )->first();
 
-        if ($conversation->exists()) {
-            return $conversation->first()->id;
+        if ($conversation) {
+            return $conversation->id;
         }
 
         return false;

--- a/src/Conversations/ConversationRepository.php
+++ b/src/Conversations/ConversationRepository.php
@@ -2,9 +2,10 @@
 
 namespace Nahid\Talk\Conversations;
 
+use Nahid\Talk\BaseRepository;
 use SebastianBerc\Repositories\Repository;
 
-class ConversationRepository extends Repository
+class ConversationRepository extends BaseRepository
 {
     /*
      * this method is default method for repository package

--- a/src/Messages/MessageRepository.php
+++ b/src/Messages/MessageRepository.php
@@ -2,9 +2,10 @@
 
 namespace Nahid\Talk\Messages;
 
+use Nahid\Talk\BaseRepository;
 use SebastianBerc\Repositories\Repository;
 
-class MessageRepository extends Repository
+class MessageRepository extends BaseRepository
 {
     public function takeModel()
     {
@@ -34,6 +35,6 @@ class MessageRepository extends Repository
         }
 
         return (boolean) $this->update($message);
-        
+
     }
 }


### PR DESCRIPTION
The *isExistsAmongTwoUsers* method of *ConversationRepository* class first performs a query to determine if a record exists, and if it does, performs another query to fetch the conversation id. Just one query is sufficient in this case.